### PR TITLE
Feat/254 256 backstage install and login

### DIFF
--- a/helm/backstage/Chart.yaml
+++ b/helm/backstage/Chart.yaml
@@ -1,28 +1,11 @@
 apiVersion: v2
 name: backstage
 description: A Helm chart for Backstage - Developer Portal
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: "1.0"
 
 dependencies:
 - name: backstage
-  version: 1.11.0
+  version: 2.6.3
   repository: https://backstage.github.io/charts

--- a/helm/backstage/Chart.yaml
+++ b/helm/backstage/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: backstage
+description: A Helm chart for Backstage - Developer Portal
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: "1.0"
+
+dependencies:
+- name: backstage
+  version: 1.11.0
+  repository: https://backstage.github.io/charts

--- a/helm/backstage/backstage-values.yaml
+++ b/helm/backstage/backstage-values.yaml
@@ -1,0 +1,67 @@
+image:
+  repository: backstage/backstage
+  tag: latest
+
+backstage:
+  extraEnvVars:
+    - name: APP_CONFIG_app_baseUrl
+      value: https://backstage.adplab.itgix.eu
+    - name: APP_CONFIG_backend_baseUrl
+      value: https://backstage.adplab.itgix.eu
+    - name: APP_CONFIG_backend_cors_origin
+      value: https://backstage.adplab.itgix.eu
+    - name: GITLAB_TOKEN
+      value: glpat-changeme
+    - name: AUTH_SECRET
+      value: my-super-secret-pass-changeme
+    - name: GITHUB_TOKEN
+      value: github_changeme
+
+  appConfig:
+    techdocs:
+      generator:
+        type: 'local'
+      publisher:
+        type: 'local'
+
+    auth:
+      # This config is often required to get the frontend to talk to the backend.
+      # We'll configure a 'guest' provider for initial testing.
+      providers:
+        guest:  # Enables unauthenticated access for testing
+          dangerouslyAllowOutsideDevelopment: true
+      session:
+        secret: ${AUTH_SECRET}
+
+    scaffolder:
+      # This array tells the scaffolder backend to include these external modules
+      modules:
+        - '@backstage/plugin-scaffolder-backend-module-gitlab'
+        # Add any other modules (e.g., github) here if needed later
+
+    integrations:
+      gitlab:
+        - host: gitlab.itgix.com
+          apiBaseUrl: https://gitlab.itgix.com/api/v4
+          token: ${GITLAB_TOKEN}
+      github:
+        - host: github.com
+          token: ${GITHUB_TOKEN}
+
+
+    catalog:
+      locations:
+        - type: url
+          target: https://github.com/itgix/adp-backstage-scaffold/blob/main/argo-helm-templates/bckstg-scaf-templ-argocd-app.yaml
+          rules:
+            - allow: [Template]
+
+ingress:
+  enabled: true
+  className: alb
+  host: backstage.adplab.itgix.eu
+  path: /
+
+postgresql:
+  enabled: true
+

--- a/helm/backstage/templates/backstage-secrets.yaml
+++ b/helm/backstage/templates/backstage-secrets.yaml
@@ -6,21 +6,39 @@ metadata:
   namespace: backstage
 type: Opaque
 stringData:
+  # Backend auth secret
   AUTH_SECRET: {{ index .Values "infra-services" "backstage_auth_secret" | quote }}
+  
+  # Organization name
+  ORGANIZATION_NAME: {{ index .Values "infra-services" "backstage_organization_name" | default "Backstage" | quote }}
+  
+  # GitLab integration
   {{- if index .Values "infra-services" "backstage_gitlab_token" }}
   GITLAB_TOKEN: {{ index .Values "infra-services" "backstage_gitlab_token" | quote }}
   {{- end }}
+  {{- if index .Values "infra-services" "backstage_gitlab_host" }}
+  GITLAB_HOST: {{ index .Values "infra-services" "backstage_gitlab_host" | quote }}
+  {{- end }}
+  {{- if index .Values "infra-services" "backstage_gitlab_api_base_url" }}
+  GITLAB_API_BASE_URL: {{ index .Values "infra-services" "backstage_gitlab_api_base_url" | quote }}
+  {{- end }}
+  
+  # GitHub integration
   {{- if index .Values "infra-services" "backstage_github_token" }}
   GITHUB_TOKEN: {{ index .Values "infra-services" "backstage_github_token" | quote }}
   {{- end }}
+  
+  # GitHub OAuth (auth provider) - note: uses AUTH_ prefix in app-config.production.yaml
   {{- if index .Values "infra-services" "backstage_github_client_id" }}
-  GITHUB_CLIENT_ID: {{ index .Values "infra-services" "backstage_github_client_id" | quote }}
+  AUTH_GITHUB_CLIENT_ID: {{ index .Values "infra-services" "backstage_github_client_id" | quote }}
   {{- end }}
   {{- if index .Values "infra-services" "backstage_github_client_secret" }}
-  GITHUB_CLIENT_SECRET: {{ index .Values "infra-services" "backstage_github_client_secret" | quote }}
+  AUTH_GITHUB_CLIENT_SECRET: {{ index .Values "infra-services" "backstage_github_client_secret" | quote }}
   {{- end }}
+  
+  # Base URLs
   {{- if index .Values "infra-services" "backstage_base_url" }}
-  BASE_URL: {{ index .Values "infra-services" "backstage_base_url" | quote }}
+  APP_BASE_URL: {{ index .Values "infra-services" "backstage_base_url" | quote }}
   {{- end }}
   {{- if index .Values "infra-services" "backstage_backend_base_url" }}
   BACKEND_BASE_URL: {{ index .Values "infra-services" "backstage_backend_base_url" | quote }}

--- a/helm/backstage/templates/backstage-secrets.yaml
+++ b/helm/backstage/templates/backstage-secrets.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.backstageAuthSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-secrets
+  namespace: backstage
+type: Opaque
+stringData:
+  auth-secret: {{ .Values.backstageAuthSecret | quote }}
+{{- end }}

--- a/helm/backstage/templates/backstage-secrets.yaml
+++ b/helm/backstage/templates/backstage-secrets.yaml
@@ -6,5 +6,23 @@ metadata:
   namespace: backstage
 type: Opaque
 stringData:
-  auth-secret: {{ index .Values "infra-services" "backstage_auth_secret" | quote }}
+  AUTH_SECRET: {{ index .Values "infra-services" "backstage_auth_secret" | quote }}
+  {{- if index .Values "infra-services" "backstage_gitlab_token" }}
+  GITLAB_TOKEN: {{ index .Values "infra-services" "backstage_gitlab_token" | quote }}
+  {{- end }}
+  {{- if index .Values "infra-services" "backstage_github_token" }}
+  GITHUB_TOKEN: {{ index .Values "infra-services" "backstage_github_token" | quote }}
+  {{- end }}
+  {{- if index .Values "infra-services" "backstage_github_client_id" }}
+  GITHUB_CLIENT_ID: {{ index .Values "infra-services" "backstage_github_client_id" | quote }}
+  {{- end }}
+  {{- if index .Values "infra-services" "backstage_github_client_secret" }}
+  GITHUB_CLIENT_SECRET: {{ index .Values "infra-services" "backstage_github_client_secret" | quote }}
+  {{- end }}
+  {{- if index .Values "infra-services" "backstage_base_url" }}
+  BASE_URL: {{ index .Values "infra-services" "backstage_base_url" | quote }}
+  {{- end }}
+  {{- if index .Values "infra-services" "backstage_backend_base_url" }}
+  BACKEND_BASE_URL: {{ index .Values "infra-services" "backstage_backend_base_url" | quote }}
+  {{- end }}
 {{- end }}

--- a/helm/backstage/templates/backstage-secrets.yaml
+++ b/helm/backstage/templates/backstage-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backstage_auth_secret }}
+{{- if index .Values "infra-services" "backstage_auth_secret" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   namespace: backstage
 type: Opaque
 stringData:
-  auth-secret: {{ .Values.backstage_auth_secret | quote }}
+  auth-secret: {{ index .Values "infra-services" "backstage_auth_secret" | quote }}
 {{- end }}

--- a/helm/backstage/templates/backstage-secrets.yaml
+++ b/helm/backstage/templates/backstage-secrets.yaml
@@ -6,13 +6,10 @@ metadata:
   namespace: backstage
 type: Opaque
 stringData:
-  # Backend auth secret
   AUTH_SECRET: {{ index .Values "infra-services" "backstage_auth_secret" | quote }}
   
-  # Organization name
   ORGANIZATION_NAME: {{ index .Values "infra-services" "backstage_organization_name" | default "Backstage" | quote }}
   
-  # GitLab integration
   {{- if index .Values "infra-services" "backstage_gitlab_token" }}
   GITLAB_TOKEN: {{ index .Values "infra-services" "backstage_gitlab_token" | quote }}
   {{- end }}
@@ -23,12 +20,10 @@ stringData:
   GITLAB_API_BASE_URL: {{ index .Values "infra-services" "backstage_gitlab_api_base_url" | quote }}
   {{- end }}
   
-  # GitHub integration
   {{- if index .Values "infra-services" "backstage_github_token" }}
   GITHUB_TOKEN: {{ index .Values "infra-services" "backstage_github_token" | quote }}
   {{- end }}
   
-  # GitHub OAuth (auth provider) - note: uses AUTH_ prefix in app-config.production.yaml
   {{- if index .Values "infra-services" "backstage_github_client_id" }}
   AUTH_GITHUB_CLIENT_ID: {{ index .Values "infra-services" "backstage_github_client_id" | quote }}
   {{- end }}
@@ -36,7 +31,6 @@ stringData:
   AUTH_GITHUB_CLIENT_SECRET: {{ index .Values "infra-services" "backstage_github_client_secret" | quote }}
   {{- end }}
   
-  # Base URLs
   {{- if index .Values "infra-services" "backstage_base_url" }}
   APP_BASE_URL: {{ index .Values "infra-services" "backstage_base_url" | quote }}
   {{- end }}

--- a/helm/backstage/templates/backstage-secrets.yaml
+++ b/helm/backstage/templates/backstage-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backstageAuthSecret }}
+{{- if .Values.backstage_auth_secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   namespace: backstage
 type: Opaque
 stringData:
-  auth-secret: {{ .Values.backstageAuthSecret | quote }}
+  auth-secret: {{ .Values.backstage_auth_secret | quote }}
 {{- end }}

--- a/helm/backstage/templates/github-token-secret.yaml
+++ b/helm/backstage/templates/github-token-secret.yaml
@@ -1,0 +1,10 @@
+{{- if index .Values "infra-services" "backstage_github_token" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+  namespace: backstage
+type: Opaque
+stringData:
+  token: {{ index .Values "infra-services" "backstage_github_token" | quote }}
+{{- end }}

--- a/helm/backstage/templates/gitlab-token-secret.yaml
+++ b/helm/backstage/templates/gitlab-token-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backstage_gitlab_token }}
+{{- if index .Values "infra-services" "backstage_gitlab_token" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   namespace: backstage
 type: Opaque
 stringData:
-  token: {{ .Values.backstage_gitlab_token | quote }}
+  token: {{ index .Values "infra-services" "backstage_gitlab_token" | quote }}
 {{- end }}

--- a/helm/backstage/templates/gitlab-token-secret.yaml
+++ b/helm/backstage/templates/gitlab-token-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.backstageGitlabToken }}
+{{- if .Values.backstage_gitlab_token }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   namespace: backstage
 type: Opaque
 stringData:
-  token: {{ .Values.backstageGitlabToken | quote }}
+  token: {{ .Values.backstage_gitlab_token | quote }}
 {{- end }}

--- a/helm/backstage/templates/gitlab-token-secret.yaml
+++ b/helm/backstage/templates/gitlab-token-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.backstageGitlabToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-token
+  namespace: backstage
+type: Opaque
+stringData:
+  token: {{ .Values.backstageGitlabToken | quote }}
+{{- end }}

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -29,7 +29,7 @@ backstage:
           dangerouslyAllowOutsideDevelopment: true
           userEntityRef: user:default/admin
       session:
-        secret: ${AUTH_SECRET
+        secret: ${AUTH_SECRET}
 
     scaffolder:
       # This array tells the scaffolder backend to include these external modules

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -66,7 +66,8 @@ backstage:
     annotations:
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+      alb.ingress.kubernetes.io/ssl-redirect: '443'
 
   postgresql:
     enabled: true

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -13,14 +13,23 @@ backstage:
       publisher:
         type: 'local'
 
+    # auth:
+    #   # This config is often required to get the frontend to talk to the backend.
+    #   # We'll configure a 'guest' provider for initial testing.
+    #   providers:
+    #     guest:  # Enables unauthenticated access for testing
+    #       dangerouslyAllowOutsideDevelopment: true
+    #   session:
+    #     secret: ${AUTH_SECRET}
+
+
     auth:
-      # This config is often required to get the frontend to talk to the backend.
-      # We'll configure a 'guest' provider for initial testing.
       providers:
-        guest:  # Enables unauthenticated access for testing
+        guest:
           dangerouslyAllowOutsideDevelopment: true
+          userEntityRef: user:default/admin
       session:
-        secret: ${AUTH_SECRET}
+        secret: ${AUTH_SECRET
 
     scaffolder:
       # This array tells the scaffolder backend to include these external modules

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -5,11 +5,11 @@ image:
 backstage:
   extraEnvVars:
     - name: APP_CONFIG_app_baseUrl
-      value: https://backstage.adplab.itgix.eu
+      value: https://{{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
     - name: APP_CONFIG_backend_baseUrl
-      value: https://backstage.adplab.itgix.eu
+      value: https://{{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
     - name: APP_CONFIG_backend_cors_origin
-      value: https://backstage.adplab.itgix.eu
+      value: https://{{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
     - name: GITLAB_TOKEN
       valueFrom:
         secretKeyRef:
@@ -65,7 +65,7 @@ backstage:
 ingress:
   enabled: true
   className: alb
-  host: backstage.adplab.itgix.eu
+  host: {{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
   path: /
 
 postgresql:

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,23 +1,4 @@
 backstage:
-  extraEnvVars:
-    - name: APP_CONFIG_app_baseUrl
-      value: https://backstage.adplab.itgix.eu
-    - name: APP_CONFIG_backend_baseUrl
-      value: https://backstage.adplab.itgix.eu
-    - name: APP_CONFIG_backend_cors_origin
-      value: https://backstage.adplab.itgix.eu
-    - name: GITLAB_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: gitlab-token
-          key: token
-    - name: AUTH_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: backstage-secrets
-          key: auth-secret
-    - name: GITHUB_TOKEN
-      value: github_changeme
 
   appConfig:
     techdocs:

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -11,9 +11,15 @@ backstage:
     - name: APP_CONFIG_backend_cors_origin
       value: https://backstage.adplab.itgix.eu
     - name: GITLAB_TOKEN
-      value: glpat-changeme
+      valueFrom:
+        secretKeyRef:
+          name: gitlab-token
+          key: token
     - name: AUTH_SECRET
-      value: my-super-secret-pass-changeme
+      valueFrom:
+        secretKeyRef:
+          name: backstage-secrets
+          key: auth-secret
     - name: GITHUB_TOKEN
       value: github_changeme
 

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,86 +1,24 @@
+# Backstage Helm Chart Values
+# Configuration is baked into the custom Docker image (app-config.production.yaml)
+# Only image settings and secrets are configured here
+
 backstage:
   backstage:
-    appConfig:
-      app:
-        title: Backstage
-        baseUrl: ${BASE_URL}
-        support:
-          url: ${BASE_URL}
-          items:
-            - title: Documentation
-              icon: docs
-              links:
-                - url: https://backstage.io/docs
-                  title: Backstage Documentation
-            - title: Support
-              icon: help
-              links:
-                - url: https://github.com/backstage/backstage/issues
-                  title: GitHub Issues
-      organization:
-        name: Backstage
-      backend:
-        auth:
-          externalAccess:
-            - type: legacy
-              options:
-                subject: legacy-default-config
-                secret: ${AUTH_SECRET}
-          providers:
-            guest:
-              dangerouslyAllowOutsideDevelopment: true
-            github:
-              enabled: true
-        baseUrl: ${BACKEND_BASE_URL}
-        listen:
-          port: 7007
+    # Custom Backstage image built from backstage-adp repo
+    image:
+      registry: ""  # Set via IDP installer, e.g., 791296381042.dkr.ecr.eu-west-1.amazonaws.com
+      repository: ""  # Set via IDP installer, e.g., backstage-adp
+      tag: ""  # Set via IDP installer, e.g., latest or specific version
+      pullSecrets: []  # Set via IDP installer if using private registry
 
-        cors:
-          origin: ${BASE_URL}
-          methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
-          credentials: true
-        csp:
-          connect-src: ["'self'", 'http:', 'https:']
-        database:
-          client: pg
-          connection:
-            host: ${POSTGRES_HOST}
-            port: ${POSTGRES_PORT}
-            user: ${POSTGRES_USER}
-            password: ${POSTGRES_PASSWORD}
-      auth:
-        environment: development
-        providers:
-          guest:
-            dangerouslyAllowOutsideDevelopment: true
-          github:
-            development:
-              clientId: ${GITHUB_CLIENT_ID}
-              clientSecret: ${GITHUB_CLIENT_SECRET}
-              signIn:
-                resolvers:
-                  - resolver: usernameMatchingUserEntityName
-      signInPage: github
-      scaffolder:
-        modules:
-          - '@backstage/plugin-scaffolder-backend-module-gitlab'
-      # Integrations use environment variables that are dynamically set
-      # GITLAB_HOST and GITLAB_API_BASE_URL are set in application-backstage.yaml
-      # based on applications_destination_repo URL
-      integrations:
-        gitlab:
-          - host: ${GITLAB_HOST}
-            apiBaseUrl: ${GITLAB_API_BASE_URL}
-            token: ${GITLAB_TOKEN}
-        github:
-          - host: github.com
-            token: ${GITHUB_TOKEN}
-      catalog:
-        locations:
-          - type: url
-            target: https://github.com/itgix/adp-backstage-scaffold/blob/main/argo-helm-templates/bckstg-scaf-templ-argocd-app.yaml
-            rules:
-              - allow: [Template]
+    # Container port must match app-config.production.yaml listen port
+    containerPorts:
+      backend: 7007
+
+    # Secrets containing environment variables for app-config.production.yaml
+    # These secrets provide values for: AUTH_SECRET, GITHUB_TOKEN, GITLAB_TOKEN,
+    # AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, APP_BASE_URL, BACKEND_BASE_URL,
+    # GITLAB_HOST, GITLAB_API_BASE_URL, ORGANIZATION_NAME
     extraEnvVarsSecrets:
       - backstage-secrets
       - backstage-postgresql

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -45,7 +45,8 @@ backstage:
 
       backend:
         baseUrl: ${BACKEND_BASE_URL}
-        listen: ':7007'
+        listen:
+          port: 7007
         auth:
           externalAccess:
             - type: legacy

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -63,6 +63,10 @@ backstage:
     className: alb
     host: backstage.adplab.itgix.eu
     path: /
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
 
   postgresql:
     enabled: true

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,27 +1,12 @@
-# Backstage Helm Chart Values
-# Base image contains minimal config (app-config.yaml)
-# Production config is injected via appConfig below
-
 backstage:
   backstage:
-    # Custom Backstage image built from backstage-adp repo
-    image:
-      registry: ""  # Set via IDP installer, e.g., gitlab.itgix.com:5050
-      repository: ""  # Set via IDP installer, e.g., iroussev/backstage-adp
-      tag: ""  # Set via IDP installer, e.g., v0.0.3
-      pullSecrets: []  # Set via IDP installer if using private registry
-
-    # Container port
     containerPorts:
       backend: 7007
 
-    # Secrets containing environment variables
     extraEnvVarsSecrets:
       - backstage-secrets
       - backstage-postgresql
 
-    # Production app configuration - customize per project
-    # This creates a ConfigMap that gets mounted automatically by the upstream chart
     appConfig:
       app:
         title: Backstage

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,70 +1,86 @@
 backstage:
+  backstage:
+    appConfig:
+      app:
+        title: Backstage
+        baseUrl: ${BASE_URL}
+        support:
+          url: ${BASE_URL}
+          items:
+            - title: Documentation
+              icon: docs
+              links:
+                - url: https://backstage.io/docs
+                  title: Backstage Documentation
+            - title: Support
+              icon: help
+              links:
+                - url: https://github.com/backstage/backstage/issues
+                  title: GitHub Issues
+      organization:
+        name: Backstage
+      backend:
+        auth:
+          externalAccess:
+            - type: legacy
+              options:
+                subject: legacy-default-config
+                secret: ${AUTH_SECRET}
+          providers:
+            guest:
+              dangerouslyAllowOutsideDevelopment: true
+            github:
+              enabled: true
+        baseUrl: ${BACKEND_BASE_URL}
+        listen:
+          port: 7007
 
-  appConfig:
-    app:
-      baseUrl: https://backstage.example.com
-    backend:
-      baseUrl: https://backstage.example.com
-      cors:
-        origin: https://backstage.example.com
-    techdocs:
-      generator:
-        type: 'local'
-      publisher:
-        type: 'local'
-
-    # auth:
-    #   # This config is often required to get the frontend to talk to the backend.
-    #   # We'll configure a 'guest' provider for initial testing.
-    #   providers:
-    #     guest:  # Enables unauthenticated access for testing
-    #       dangerouslyAllowOutsideDevelopment: true
-    #   session:
-    #     secret: ${AUTH_SECRET}
-
-
-    auth:
-      providers:
-        guest:
-          dangerouslyAllowOutsideDevelopment: true
-          userEntityRef: user:default/admin
-      session:
-        secret: ${AUTH_SECRET}
-
-    scaffolder:
-      # This array tells the scaffolder backend to include these external modules
-      modules:
-        - '@backstage/plugin-scaffolder-backend-module-gitlab'
-        # Add any other modules (e.g., github) here if needed later
-
-    integrations:
-      gitlab:
-        - host: gitlab.itgix.com
-          apiBaseUrl: https://gitlab.itgix.com/api/v4
-          token: ${GITLAB_TOKEN}
-      github:
-        - host: github.com
-          token: ${GITHUB_TOKEN}
-
-
-    catalog:
-      locations:
-        - type: url
-          target: https://github.com/itgix/adp-backstage-scaffold/blob/main/argo-helm-templates/bckstg-scaf-templ-argocd-app.yaml
-          rules:
-            - allow: [Template]
-
-  ingress:
-    enabled: true
-    className: alb
-    host: backstage.adplab.itgix.eu
-    path: /
-    annotations:
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-      alb.ingress.kubernetes.io/ssl-redirect: '443'
-
-  postgresql:
-    enabled: true
-
+        cors:
+          origin: ${BASE_URL}
+          methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+          credentials: true
+        csp:
+          connect-src: ["'self'", 'http:', 'https:']
+        database:
+          client: pg
+          connection:
+            host: ${POSTGRES_HOST}
+            port: ${POSTGRES_PORT}
+            user: ${POSTGRES_USER}
+            password: ${POSTGRES_PASSWORD}
+      auth:
+        environment: development
+        providers:
+          guest:
+            dangerouslyAllowOutsideDevelopment: true
+          github:
+            development:
+              clientId: ${GITHUB_CLIENT_ID}
+              clientSecret: ${GITHUB_CLIENT_SECRET}
+              signIn:
+                resolvers:
+                  - resolver: usernameMatchingUserEntityName
+      signInPage: github
+      scaffolder:
+        modules:
+          - '@backstage/plugin-scaffolder-backend-module-gitlab'
+      # Integrations use environment variables that are dynamically set
+      # GITLAB_HOST and GITLAB_API_BASE_URL are set in application-backstage.yaml
+      # based on applications_destination_repo URL
+      integrations:
+        gitlab:
+          - host: ${GITLAB_HOST}
+            apiBaseUrl: ${GITLAB_API_BASE_URL}
+            token: ${GITLAB_TOKEN}
+        github:
+          - host: github.com
+            token: ${GITHUB_TOKEN}
+      catalog:
+        locations:
+          - type: url
+            target: https://github.com/itgix/adp-backstage-scaffold/blob/main/argo-helm-templates/bckstg-scaf-templ-argocd-app.yaml
+            rules:
+              - allow: [Template]
+    extraEnvVarsSecrets:
+      - backstage-secrets
+      - backstage-postgresql

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,11 +1,11 @@
 backstage:
   extraEnvVars:
     - name: APP_CONFIG_app_baseUrl
-      value: https://{{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
+      value: https://backstage.adplab.itgix.eu
     - name: APP_CONFIG_backend_baseUrl
-      value: https://{{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
+      value: https://backstage.adplab.itgix.eu
     - name: APP_CONFIG_backend_cors_origin
-      value: https://{{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
+      value: https://backstage.adplab.itgix.eu
     - name: GITLAB_TOKEN
       valueFrom:
         secretKeyRef:
@@ -61,7 +61,7 @@ backstage:
   ingress:
     enabled: true
     className: alb
-    host: {{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
+    host: backstage.adplab.itgix.eu
     path: /
 
   postgresql:

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,7 +1,3 @@
-image:
-  repository: backstage/backstage
-  tag: latest
-
 backstage:
   extraEnvVars:
     - name: APP_CONFIG_app_baseUrl
@@ -62,12 +58,12 @@ backstage:
           rules:
             - allow: [Template]
 
-ingress:
-  enabled: true
-  className: alb
-  host: {{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
-  path: /
+  ingress:
+    enabled: true
+    className: alb
+    host: {{ .Values.backstage_ingress_host | default "backstage.adplab.itgix.eu" }}
+    path: /
 
-postgresql:
-  enabled: true
+  postgresql:
+    enabled: true
 

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,6 +1,12 @@
 backstage:
 
   appConfig:
+    app:
+      baseUrl: https://backstage.example.com
+    backend:
+      baseUrl: https://backstage.example.com
+      cors:
+        origin: https://backstage.example.com
     techdocs:
       generator:
         type: 'local'

--- a/helm/backstage/values.yaml
+++ b/helm/backstage/values.yaml
@@ -1,24 +1,103 @@
 # Backstage Helm Chart Values
-# Configuration is baked into the custom Docker image (app-config.production.yaml)
-# Only image settings and secrets are configured here
+# Base image contains minimal config (app-config.yaml)
+# Production config is injected via appConfig below
 
 backstage:
   backstage:
     # Custom Backstage image built from backstage-adp repo
     image:
-      registry: ""  # Set via IDP installer, e.g., 791296381042.dkr.ecr.eu-west-1.amazonaws.com
-      repository: ""  # Set via IDP installer, e.g., backstage-adp
-      tag: ""  # Set via IDP installer, e.g., latest or specific version
+      registry: ""  # Set via IDP installer, e.g., gitlab.itgix.com:5050
+      repository: ""  # Set via IDP installer, e.g., iroussev/backstage-adp
+      tag: ""  # Set via IDP installer, e.g., v0.0.3
       pullSecrets: []  # Set via IDP installer if using private registry
 
-    # Container port must match app-config.production.yaml listen port
+    # Container port
     containerPorts:
       backend: 7007
 
-    # Secrets containing environment variables for app-config.production.yaml
-    # These secrets provide values for: AUTH_SECRET, GITHUB_TOKEN, GITLAB_TOKEN,
-    # AUTH_GITHUB_CLIENT_ID, AUTH_GITHUB_CLIENT_SECRET, APP_BASE_URL, BACKEND_BASE_URL,
-    # GITLAB_HOST, GITLAB_API_BASE_URL, ORGANIZATION_NAME
+    # Secrets containing environment variables
     extraEnvVarsSecrets:
       - backstage-secrets
       - backstage-postgresql
+
+    # Production app configuration - customize per project
+    # This creates a ConfigMap that gets mounted automatically by the upstream chart
+    appConfig:
+      app:
+        title: Backstage
+        baseUrl: ${APP_BASE_URL}
+        support:
+          url: ${APP_BASE_URL}
+          items:
+            - title: Documentation
+              icon: docs
+              links:
+                - url: https://backstage.io/docs
+                  title: Backstage Documentation
+            - title: Support
+              icon: help
+              links:
+                - url: https://github.com/backstage/backstage/issues
+                  title: GitHub Issues
+
+      organization:
+        name: ${ORGANIZATION_NAME}
+
+      backend:
+        baseUrl: ${BACKEND_BASE_URL}
+        listen: ':7007'
+        auth:
+          externalAccess:
+            - type: legacy
+              options:
+                subject: legacy-default-config
+                secret: ${AUTH_SECRET}
+        cors:
+          origin: ${APP_BASE_URL}
+          methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+          credentials: true
+        csp:
+          connect-src: ["'self'", 'http:', 'https:']
+        database:
+          client: pg
+          connection:
+            host: ${POSTGRES_HOST}
+            port: ${POSTGRES_PORT}
+            user: ${POSTGRES_USER}
+            password: ${POSTGRES_PASSWORD}
+
+      auth:
+        environment: production
+        providers:
+          github:
+            production:
+              clientId: ${AUTH_GITHUB_CLIENT_ID}
+              clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+              callbackUrl: ${BACKEND_BASE_URL}/api/auth/github/handler/frame
+              signIn:
+                resolvers:
+                  - resolver: usernameMatchingUserEntityName
+          guest:
+            dangerouslyAllowOutsideDevelopment: true
+
+      signInPage: github
+
+      integrations:
+        github:
+          - host: github.com
+            token: ${GITHUB_TOKEN}
+        gitlab:
+          - host: ${GITLAB_HOST}
+            apiBaseUrl: ${GITLAB_API_BASE_URL}
+            token: ${GITLAB_TOKEN}
+
+      catalog:
+        locations:
+          - type: url
+            target: https://github.com/itgix/adp-backstage-scaffold/blob/main/argo-helm-templates/bckstg-scaf-templ-argocd-app.yaml
+            rules:
+              - allow: [Template]
+          - type: file
+            target: ./examples/org.yaml
+            rules:
+              - allow: [User, Group]

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -17,31 +17,6 @@ spec:
       valueFiles:
         - ../backstage/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
-      values: |
-        {{- if index .Values "infra-services" "backstage_gitlab_token" }}
-        backstageGitlabToken: {{ index .Values "infra-services" "backstage_gitlab_token" | quote }}
-        {{- end }}
-        {{- if index .Values "infra-services" "backstage_auth_secret" }}
-        backstageAuthSecret: {{ index .Values "infra-services" "backstage_auth_secret" | quote }}
-        {{- end }}
-        backstage:
-          extraEnvVars:
-            - name: APP_CONFIG_app_baseUrl
-              value: https://{{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
-            - name: APP_CONFIG_backend_baseUrl
-              value: https://{{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
-            - name: APP_CONFIG_backend_cors_origin
-              value: https://{{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
-        ingress:
-          enabled: true
-          className: alb
-          annotations:
-            alb.ingress.kubernetes.io/scheme: internet-facing
-            alb.ingress.kubernetes.io/target-type: ip
-            alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-            alb.ingress.kubernetes.io/ssl-redirect: '443'
-            external-dns.alpha.kubernetes.io/hostname: {{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
-          host: {{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -17,6 +17,19 @@ spec:
       valueFiles:
         - ../backstage/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
+      values: |
+        backstage:
+          extraEnvVars:
+            - name: APP_CONFIG_app_baseUrl
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: APP_CONFIG_backend_baseUrl
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: APP_CONFIG_backend_cors_origin
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          ingress:
+            enabled: true
+            className: alb
+            host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -18,25 +18,27 @@ spec:
         - ../backstage/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
-        extraEnvVars:
-          - name: APP_CONFIG_app_baseUrl
-            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          - name: APP_CONFIG_backend_baseUrl
-            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          - name: APP_CONFIG_backend_cors_origin
-            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          - name: GITLAB_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: gitlab-token
-                key: token
-          - name: AUTH_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: backstage-secrets
-                key: auth-secret
-          - name: GITHUB_TOKEN
-            value: github_changeme
+        backstage:
+          appConfig:
+            app:
+              baseUrl: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            backend:
+              baseUrl: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+              cors:
+                origin: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          extraEnvVars:
+            - name: GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gitlab-token
+                  key: token
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-secrets
+                  key: auth-secret
+            - name: GITHUB_TOKEN
+              value: github_changeme
         ingress:
           enabled: true
           className: alb

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -18,34 +18,35 @@ spec:
         - values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
-        extraEnvVars:
-          - name: APP_CONFIG_app_baseUrl
-            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          - name: APP_CONFIG_backend_baseUrl
-            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          - name: APP_CONFIG_backend_cors_origin
-            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          - name: GITLAB_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: gitlab-token
-                key: token
-          - name: AUTH_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: backstage-secrets
-                key: auth-secret
-          - name: GITHUB_TOKEN
-            value: github_changeme
-        ingress:
-          enabled: true
-          className: alb
-          host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          annotations:
-            alb.ingress.kubernetes.io/scheme: internet-facing
-            alb.ingress.kubernetes.io/target-type: ip
-            alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-            alb.ingress.kubernetes.io/ssl-redirect: '443'
+        backstage:
+          extraEnvVars:
+            - name: APP_CONFIG_app_baseUrl
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: APP_CONFIG_backend_baseUrl
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: APP_CONFIG_backend_cors_origin
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gitlab-token
+                  key: token
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-secrets
+                  key: auth-secret
+            - name: GITHUB_TOKEN
+              value: github_changeme
+          ingress:
+            enabled: true
+            className: alb
+            host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            annotations:
+              alb.ingress.kubernetes.io/scheme: internet-facing
+              alb.ingress.kubernetes.io/target-type: ip
+              alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+              alb.ingress.kubernetes.io/ssl-redirect: '443'
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -39,15 +39,15 @@ spec:
                   key: auth-secret
             - name: GITHUB_TOKEN
               value: github_changeme
-        ingress:
-          enabled: true
-          className: alb
-          host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-          annotations:
-            alb.ingress.kubernetes.io/scheme: internet-facing
-            alb.ingress.kubernetes.io/target-type: ip
-            alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-            alb.ingress.kubernetes.io/ssl-redirect: '443'
+          ingress:
+            enabled: true
+            className: alb
+            host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            annotations:
+              alb.ingress.kubernetes.io/scheme: internet-facing
+              alb.ingress.kubernetes.io/target-type: ip
+              alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+              alb.ingress.kubernetes.io/ssl-redirect: '443'
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -15,7 +15,7 @@ spec:
     path: helm/backstage
     helm:
       valueFiles:
-        - ../backstage/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
+        - values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
         backstage:
@@ -25,7 +25,7 @@ spec:
             - name: APP_CONFIG_backend_baseUrl
               value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
             - name: APP_CONFIG_backend_cors_origin
-              values: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
             - name: GITLAB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -15,7 +15,7 @@ spec:
     path: helm/backstage
     helm:
       valueFiles:
-        - ../backstage/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
+        - ../backstage/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
         backstage:
@@ -26,6 +26,18 @@ spec:
               value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
             - name: APP_CONFIG_backend_cors_origin
               value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gitlab-token
+                  key: token
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: backstage-secrets
+                  key: auth-secret
+            - name: GITHUB_TOKEN
+              value: github_changeme
           ingress:
             enabled: true
             className: alb

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -33,7 +33,8 @@ spec:
             annotations:
               alb.ingress.kubernetes.io/scheme: internet-facing
               alb.ingress.kubernetes.io/target-type: ip
-              alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+              alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+              alb.ingress.kubernetes.io/ssl-redirect: '443'
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -1,4 +1,14 @@
 {{- if index .Values "infra-services" "backstage_enabled" }}
+{{- $appsRepo := index .Values "infra-services" "applications_destination_repo" | default "" }}
+{{- /* Extract host from applications_destination_repo URL */ -}}
+{{- $appsRepoHost := "" }}
+{{- $appsRepoIsGitlab := false }}
+{{- $appsRepoIsGithub := false }}
+{{- if $appsRepo }}
+  {{- $appsRepoHost = regexReplaceAll "^(https?://|git@)([^/:]+).*" $appsRepo "${2}" }}
+  {{- $appsRepoIsGitlab = contains "gitlab" $appsRepoHost }}
+  {{- $appsRepoIsGithub = contains "github" $appsRepoHost }}
+{{- end }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -21,26 +31,24 @@ spec:
         backstage:
           backstage:
             extraEnvVars:
-              - name: APP_CONFIG_app_baseUrl
+              - name: BASE_URL
                 value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-              - name: APP_CONFIG_backend_baseUrl
+              - name: BACKEND_BASE_URL
                 value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-              - name: APP_CONFIG_backend_cors_origin
-                value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-              - name: GITLAB_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: gitlab-token
-                    key: token
-              - name: AUTH_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    name: backstage-secrets
-                    key: auth-secret
-              - name: GITHUB_TOKEN
-                value: github_changeme
-              - name: APP_CONFIG_auth_providers_guest_userEntityRef
-                value: "user:default/admin"
+              {{- if $appsRepoIsGitlab }}
+              - name: GITLAB_HOST
+                value: {{ $appsRepoHost }}
+              - name: GITLAB_API_BASE_URL
+                value: https://{{ $appsRepoHost }}/api/v4
+              {{- end }}
+            extraEnvVarsSecrets:
+              - backstage-secrets
+              {{- if $appsRepoIsGitlab }}
+              - gitlab-token
+              {{- end }}
+              {{- if or $appsRepoIsGithub (index .Values "infra-services" "backstage_github_token") }}
+              - github-token
+              {{- end }}
           ingress:
             enabled: true
             className: alb

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -30,8 +30,20 @@ spec:
       values: |
         backstage:
           backstage:
+            {{- if index .Values "infra-services" "backstage_image_registry" }}
+            image:
+              registry: {{ index .Values "infra-services" "backstage_image_registry" }}
+              repository: {{ index .Values "infra-services" "backstage_image_repository" }}
+              tag: {{ index .Values "infra-services" "backstage_image_tag" | default "latest" }}
+              {{- if index .Values "infra-services" "backstage_image_pull_secrets" }}
+              pullSecrets:
+                {{- range index .Values "infra-services" "backstage_image_pull_secrets" }}
+                - {{ . }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
             extraEnvVars:
-              - name: BASE_URL
+              - name: APP_BASE_URL
                 value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
               - name: BACKEND_BASE_URL
                 value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -39,6 +39,8 @@ spec:
                     key: auth-secret
               - name: GITHUB_TOKEN
                 value: github_changeme
+              - name: APP_CONFIG_auth_providers_guest_userEntityRef
+                value: "user:default/admin"
           ingress:
             enabled: true
             className: alb

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -18,35 +18,34 @@ spec:
         - ../backstage/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
-        backstage:
-          extraEnvVars:
-            - name: APP_CONFIG_app_baseUrl
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: APP_CONFIG_backend_baseUrl
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: APP_CONFIG_backend_cors_origin
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: GITLAB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: gitlab-token
-                  key: token
-            - name: AUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: backstage-secrets
-                  key: auth-secret
-            - name: GITHUB_TOKEN
-              value: github_changeme
-          ingress:
-            enabled: true
-            className: alb
-            host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            annotations:
-              alb.ingress.kubernetes.io/scheme: internet-facing
-              alb.ingress.kubernetes.io/target-type: ip
-              alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-              alb.ingress.kubernetes.io/ssl-redirect: '443'
+        extraEnvVars:
+          - name: APP_CONFIG_app_baseUrl
+            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          - name: APP_CONFIG_backend_baseUrl
+            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          - name: APP_CONFIG_backend_cors_origin
+            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          - name: GITLAB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: gitlab-token
+                key: token
+          - name: AUTH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: backstage-secrets
+                key: auth-secret
+          - name: GITHUB_TOKEN
+            value: github_changeme
+        ingress:
+          enabled: true
+          className: alb
+          host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          annotations:
+            alb.ingress.kubernetes.io/scheme: internet-facing
+            alb.ingress.kubernetes.io/target-type: ip
+            alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+            alb.ingress.kubernetes.io/ssl-redirect: '443'
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -15,18 +15,17 @@ spec:
     path: helm/backstage
     helm:
       valueFiles:
-        - ../backstage/values.yaml
+        - ../backstage/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
         backstage:
-          appConfig:
-            app:
-              baseUrl: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            backend:
-              baseUrl: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-              cors:
-                origin: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
           extraEnvVars:
+            - name: APP_CONFIG_app_baseUrl
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: APP_CONFIG_backend_baseUrl
+              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            - name: APP_CONFIG_backend_cors_origin
+              values: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
             - name: GITLAB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -19,25 +19,26 @@ spec:
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
         backstage:
-          extraEnvVars:
-            - name: APP_CONFIG_app_baseUrl
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: APP_CONFIG_backend_baseUrl
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: APP_CONFIG_backend_cors_origin
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: GITLAB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: gitlab-token
-                  key: token
-            - name: AUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: backstage-secrets
-                  key: auth-secret
-            - name: GITHUB_TOKEN
-              value: github_changeme
+          backstage:
+            extraEnvVars:
+              - name: APP_CONFIG_app_baseUrl
+                value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+              - name: APP_CONFIG_backend_baseUrl
+                value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+              - name: APP_CONFIG_backend_cors_origin
+                value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+              - name: GITLAB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: gitlab-token
+                    key: token
+              - name: AUTH_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: backstage-secrets
+                    key: auth-secret
+              - name: GITHUB_TOKEN
+                value: github_changeme
           ingress:
             enabled: true
             className: alb

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -35,12 +35,8 @@ spec:
               registry: {{ index .Values "infra-services" "backstage_image_registry" }}
               repository: {{ index .Values "infra-services" "backstage_image_repository" }}
               tag: {{ index .Values "infra-services" "backstage_image_tag" | default "latest" }}
-              {{- if index .Values "infra-services" "backstage_image_pull_secrets" }}
               pullSecrets:
-                {{- range index .Values "infra-services" "backstage_image_pull_secrets" }}
-                - {{ . }}
-                {{- end }}
-              {{- end }}
+                - gitlab-registry-secret
             {{- end }}
             extraEnvVars:
               - name: APP_BASE_URL

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -18,35 +18,34 @@ spec:
         - values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
         - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
       values: |
-        backstage:
-          extraEnvVars:
-            - name: APP_CONFIG_app_baseUrl
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: APP_CONFIG_backend_baseUrl
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: APP_CONFIG_backend_cors_origin
-              value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            - name: GITLAB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: gitlab-token
-                  key: token
-            - name: AUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: backstage-secrets
-                  key: auth-secret
-            - name: GITHUB_TOKEN
-              value: github_changeme
-          ingress:
-            enabled: true
-            className: alb
-            host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
-            annotations:
-              alb.ingress.kubernetes.io/scheme: internet-facing
-              alb.ingress.kubernetes.io/target-type: ip
-              alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
-              alb.ingress.kubernetes.io/ssl-redirect: '443'
+        extraEnvVars:
+          - name: APP_CONFIG_app_baseUrl
+            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          - name: APP_CONFIG_backend_baseUrl
+            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          - name: APP_CONFIG_backend_cors_origin
+            value: https://{{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          - name: GITLAB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: gitlab-token
+                key: token
+          - name: AUTH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: backstage-secrets
+                key: auth-secret
+          - name: GITHUB_TOKEN
+            value: github_changeme
+        ingress:
+          enabled: true
+          className: alb
+          host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+          annotations:
+            alb.ingress.kubernetes.io/scheme: internet-facing
+            alb.ingress.kubernetes.io/target-type: ip
+            alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+            alb.ingress.kubernetes.io/ssl-redirect: '443'
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -1,0 +1,55 @@
+{{- if index .Values "infra-services" "backstage_enabled" }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backstage
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infra
+  source:
+    repoURL: {{ index .Values "infra-services" "gitops_destination_repo" }}
+    targetRevision: HEAD
+    path: helm/backstage
+    helm:
+      valueFiles:
+        - ../backstage/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/values.yaml
+        - ../infra-services/values/{{ index .Values "infra-services" "environment" }}/{{ index .Values "infra-services" "region" }}/infra-facts.yaml
+      values: |
+        {{- if index .Values "infra-services" "backstage_gitlab_token" }}
+        backstageGitlabToken: {{ index .Values "infra-services" "backstage_gitlab_token" | quote }}
+        {{- end }}
+        {{- if index .Values "infra-services" "backstage_auth_secret" }}
+        backstageAuthSecret: {{ index .Values "infra-services" "backstage_auth_secret" | quote }}
+        {{- end }}
+        backstage:
+          extraEnvVars:
+            - name: APP_CONFIG_app_baseUrl
+              value: https://{{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
+            - name: APP_CONFIG_backend_baseUrl
+              value: https://{{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
+            - name: APP_CONFIG_backend_cors_origin
+              value: https://{{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
+        ingress:
+          enabled: true
+          className: alb
+          annotations:
+            alb.ingress.kubernetes.io/scheme: internet-facing
+            alb.ingress.kubernetes.io/target-type: ip
+            alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+            alb.ingress.kubernetes.io/ssl-redirect: '443'
+            external-dns.alpha.kubernetes.io/hostname: {{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
+          host: {{ index .Values "infra-services" "project_name" }}-{{ index .Values "infra-services" "region" }}-backstage-{{ index .Values "infra-services" "environment" }}.{{ index .Values "infra-services" "main_domain" }}
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: backstage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  revisionHistoryLimit: 3
+{{- end }}

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -1,6 +1,5 @@
 {{- if index .Values "infra-services" "backstage_enabled" }}
 {{- $appsRepo := index .Values "infra-services" "applications_destination_repo" | default "" }}
-{{- /* Extract host from applications_destination_repo URL */ -}}
 {{- $appsRepoHost := "" }}
 {{- $appsRepoIsGitlab := false }}
 {{- $appsRepoIsGithub := false }}

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -30,6 +30,10 @@ spec:
             enabled: true
             className: alb
             host: {{ index .Values "infra-services" "backstage_ingress_host" | default (printf "%s-%s-backstage-%s.%s" (index .Values "infra-services" "project_name") (index .Values "infra-services" "region") (index .Values "infra-services" "environment") (index .Values "infra-services" "domain")) }}
+            annotations:
+              alb.ingress.kubernetes.io/scheme: internet-facing
+              alb.ingress.kubernetes.io/target-type: ip
+              alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/templates/application-backstage.yaml
+++ b/helm/infra-services/templates/application-backstage.yaml
@@ -66,6 +66,7 @@ spec:
               alb.ingress.kubernetes.io/target-type: ip
               alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
               alb.ingress.kubernetes.io/ssl-redirect: '443'
+              alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: backstage

--- a/helm/infra-services/values.yaml
+++ b/helm/infra-services/values.yaml
@@ -14,6 +14,7 @@ infra-services:
   enable_prometheus_stack: false
   enable_tempo: false
   enable_loki: false
+  backstage_enabled: false
 
   aws-load-balancer-controller-version: 1.7.1
   secrets-operator-version: 0.9.12


### PR DESCRIPTION
Pull Request for Installation for backstage and Integration of Github Login Provider.

Also made feature in application-backstage.yaml: 

if applications_destination_repo url is gitlab  only gitlab secret gitlab-token-secret.yaml with token will be created and same with github only github-token-secret.yaml secret with token will be created and injected into pod as env.